### PR TITLE
index.ts: add stringlen check for cloudformation roleNames

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -164,7 +164,12 @@ export class KeyPair extends cdk.Construct implements cdk.ITaggable {
 
     const stack = cdk.Stack.of(this).stackName;
     this.prefix = props.resourcePrefix || stack;
-
+     if (this.prefix.length + cleanID.length > 62)
+            // Cloudformation limits names to 63 characters.
+            cdk.Annotations.of(this).addError(
+                `Cloudformation limits names to 63 characters.
+                 Prefix ${this.prefix} is too long to be used as a prefix for your roleName. Define parameter resourcePrefix?:`
+            );
     this.lambda = this.ensureLambda();
 
     this.tags = new cdk.TagManager(cdk.TagType.MAP, 'Custom::EC2-Key-Pair');


### PR DESCRIPTION
I used this construct in my cdk infra code, it solved the keypair problem really nicely.

However, the stack failed to deploy due to the length of the name of the key-manager role, where the prefix was derived from the name of the stack, and the stack was nested.
Cloudformation has a 64 char limit on names. 
 ### Error: 
```
Resource handler returned message: 
"1 validation error detected: Value <StackName-NestedStackName> 
at 'functionName' failed to satisfy constraint: 
Member must have length less than or equal to 64.
```

The commit should fix this issue
Let me know what you think!

Thanks :) 
