### PR TITLE
key => keyPairName

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ key.grantReadOnPublicKey(anotherRole)
 
 // Use Key Pair on an EC2 instance
 new ec2.Instance(this, 'An-Instance', {
-    keyName: key.name,
+    keyName: key.keyPairName,
     // ...
 })
 ```


### PR DESCRIPTION
Updates example in README to use `keyPairName` instead of `key` (invalid attribute)