### PR TITLE
Bump cdk-iam-floyd to latest version (0.303.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "aws-cdk-lib": "^2.0.0",
     "@types/aws-lambda": "^8.10.68",
-    "cdk-iam-floyd": "^0.300.0",
+    "cdk-iam-floyd": "^0.303.0",
     "@types/node": "14.14.16",
     "aws-lambda": "^1.0.6",
     "aws-sdk": "^2.817.0",
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.0.0",
-    "cdk-iam-floyd": "^0.300.0",
+    "cdk-iam-floyd": "^0.303.0",
     "constructs": "^10.0.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.x",
-    "cdk-iam-floyd": "0.301.0",
+    "cdk-iam-floyd": "0.303.0",
     "cdk-ssm-document": "file:.."
   }
 }


### PR DESCRIPTION
cdk-iam-floyd version 0.303.0 was released a week ago.   This bumps the version accordingly in `package.json` and `test/package.json`.   

Is there a reason why the exact version is pinned down in `test/package.json`?   Or should it also use the caret? 
```
    "cdk-iam-floyd": "^0.303.0",
```

Cheers