### PR TITLE
feat: remove the function name

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -204,13 +204,6 @@ export class KeyPair extends Construct implements ITaggable {
     }
 
     const stack = Stack.of(this).stackName;
-    this.prefix = props.resourcePrefix || stack;
-    if (this.prefix.length + cleanID.length > 62)
-      // Cloudformation limits names to 63 characters.
-      Annotations.of(this).addError(
-        `Cloudformation limits names to 63 characters.
-         Prefix ${this.prefix} is too long to be used as a prefix for your roleName. Define parameter resourcePrefix?:`
-      );
     this.lambda = this.ensureLambda();
 
     this.tags = new TagManager(TagType.MAP, 'Custom::EC2-Key-Pair');
@@ -279,7 +272,6 @@ export class KeyPair extends Construct implements ITaggable {
       stack,
       'EC2-Key-Pair-Manager-Policy',
       {
-        managedPolicyName: `${this.prefix}-${cleanID}`,
         description: `Used by Lambda ${cleanID}, which is a custom CFN resource, managing EC2 Key Pairs`,
         statements: [
           new aws_iam.PolicyStatement({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -367,9 +367,8 @@ export class KeyPair extends Construct implements ITaggable {
     });
 
     const fn = new aws_lambda.Function(stack, constructName, {
-      functionName: `${this.prefix}-${cleanID}`,
-      role: role,
-      description: 'Custom CFN resource: Manage EC2 Key Pairs',
+      role,
+      description: `${this.prefix}-${cleanID} Custom CFN resource: Manage EC2 Key Pairs`,
       runtime: aws_lambda.Runtime.NODEJS_14_X,
       handler: 'index.handler',
       code: aws_lambda.Code.fromAsset(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,7 @@ import {
   TagType,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import path = require('path');
+import * as path from 'path';
 
 const resourceType = 'Custom::EC2-Key-Pair';
 const ID = `CFN::Resource::${resourceType}`;


### PR DESCRIPTION
Named functions are more trouble than they're worth.
The description provides the same value, without the annoyance.

Fixes: #53
