### PR TITLE
fix: resourcePrefix should allow empty string

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -204,7 +204,7 @@ export class KeyPair extends Construct implements ITaggable {
     }
 
     const stack = Stack.of(this).stackName;
-    this.prefix = props.resourcePrefix || stack;
+    this.prefix = props.resourcePrefix ?? stack;
     if (this.prefix.length + cleanID.length > 62)
       // Cloudformation limits names to 63 characters.
       Annotations.of(this).addError(


### PR DESCRIPTION
The ?? operator tests for undefined rather than falsy.
