### PR TITLE
fix compatibility with feat: resourcePrefix should allow empty string

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -204,7 +204,8 @@ export class KeyPair extends Construct implements ITaggable {
     }
 
     const stack = Stack.of(this).stackName;
-    this.prefix = props.resourcePrefix ?? stack;
+    this.prefix =
+      props.resourcePrefix !== undefined ? props.resourcePrefix : stack;
     if (this.prefix.length + cleanID.length > 62)
       // Cloudformation limits names to 63 characters.
       Annotations.of(this).addError(


### PR DESCRIPTION
During release jsii fails with:

```
/github/workspace/node_modules/jsii/bin/jsii.js:89
    (0, jsii_diagnostic_1.configureCategories)(projectInfo.diagnostics ?? {});
                                                                        ^

SyntaxError: Unexpected token ?
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/github/workspace/node_modules/jsii/bin/jsii:2:1)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
```

Problem was introduced via #55