### PR TITLE
feat!: removes fixed name from lambda function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,3 @@ install:
 	@echo -e "$(TARGET_COLOR)Running install$(NO_COLOR)"
 	@npm clean-install --prefer-offline --cache .npm
 	@npm list
-
-test: build
-	@echo -e "$(TARGET_COLOR)Running test$(NO_COLOR)"
-	@npm run test
-
-test-update:
-	@echo -e "$(TARGET_COLOR)Running test-update$(NO_COLOR)"
-	@npm run test -- -u

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -356,12 +356,8 @@ export class KeyPair extends Construct implements ITaggable {
       }),
     ];
 
-    const functionName = legacyLambdaName
-      ? `${this.prefix}-${cleanID}`
-      : undefined;
-
     const fn = new aws_lambda.Function(stack, constructName, {
-      functionName,
+      functionName: legacyLambdaName ? `${this.prefix}-${cleanID}` : undefined,
       description: 'Custom CFN resource: Manage EC2 Key Pairs',
       runtime: aws_lambda.Runtime.NODEJS_18_X,
       handler: 'index.handler',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -359,13 +359,10 @@ export class KeyPair extends Construct implements ITaggable {
     const functionName = legacyLambdaName
       ? `${this.prefix}-${cleanID}`
       : undefined;
-    const description =
-      (legacyLambdaName ? `${this.prefix}-${cleanID} ` : '') +
-      'Custom CFN resource: Manage EC2 Key Pairs';
 
     const fn = new aws_lambda.Function(stack, constructName, {
       functionName,
-      description,
+      description: 'Custom CFN resource: Manage EC2 Key Pairs',
       runtime: aws_lambda.Runtime.NODEJS_18_X,
       handler: 'index.handler',
       code: aws_lambda.Code.fromAsset(

--- a/test/bin/test.ts
+++ b/test/bin/test.ts
@@ -1,11 +1,32 @@
 #!/usr/bin/env node
-import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import {
+  GetCallerIdentityCommand,
+  STSClient,
+  STSClientConfig,
+} from '@aws-sdk/client-sts';
 import cdk = require('aws-cdk-lib');
 
 import { TestStack } from '../lib/test-stack';
 
+const region = 'us-east-1';
+
+const clientConfig: STSClientConfig = {
+  region,
+};
+if (
+  process.env.AWS_ACCESS_KEY_ID &&
+  process.env.AWS_SECRET_ACCESS_KEY &&
+  process.env.AWS_SESSION_TOKEN
+) {
+  clientConfig.credentials = {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
+  };
+}
+
 async function getIdentity() {
-  const stsClient = new STSClient({});
+  const stsClient = new STSClient(clientConfig);
   const callerIdentity = await stsClient.send(new GetCallerIdentityCommand({}));
   return callerIdentity.Arn?.split('/')[1] as string;
 }

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -53,7 +53,7 @@ export class TestStack extends cdk.Stack {
       exposePublicKey: true,
       storePublicKey: true,
       publicKeyFormat: PublicKeyFormat.PEM,
-      legacyResourceNames: true,
+      legacyLambdaName: true,
     });
 
     const currentUser = cdk.aws_iam.User.fromUserName(

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -53,6 +53,7 @@ export class TestStack extends cdk.Stack {
       exposePublicKey: true,
       storePublicKey: true,
       publicKeyFormat: PublicKeyFormat.PEM,
+      legacyResourceNames: true,
     });
 
     const currentUser = cdk.aws_iam.User.fromUserName(


### PR DESCRIPTION
Giving the Lambda function, which manages the custom resources, a fixed name caused problems for some users. This change makes the name of the Lambda function configurable.

By default, the Lambda function now does not have a fixed name, letting CDK generate a unique name.

### Migration guide
If you migrate from v3 to v4, you need to set the property `legacyLambdaName` to `true` as CloudFormation does not allow to change the name of the Lambda function used by custom resource.

Fixes #53
Closes #54