### PR TITLE
feat!: for consistency, the property name now is renamed to keyPairName

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,7 +37,7 @@ export interface KeyPairProps extends ResourceProps {
    *
    * The name can be up to 255 characters long. Valid characters include _, -, a-z, A-Z, and 0-9.
    */
-  readonly name: string;
+  readonly keyPairName: string;
 
   /**
    * The description for the key in AWS Secrets Manager
@@ -234,11 +234,11 @@ export class KeyPair extends Construct implements ITaggable {
     const kmsPrivate = props.kmsPrivateKey || props.kms;
     const kmsPublic = props.kmsPublicKey || props.kms;
 
-    const key = new CustomResource(this, `EC2-Key-Pair-${props.name}`, {
+    const key = new CustomResource(this, `EC2-Key-Pair-${props.keyPairName}`, {
       serviceToken: this.lambda.functionArn,
       resourceType: resourceType,
       properties: {
-        Name: props.name,
+        Name: props.keyPairName,
         Description: props.description || '',
         KmsPrivate: kmsPrivate?.keyArn || 'alias/aws/secretsmanager',
         KmsPublic: kmsPublic?.keyArn || 'alias/aws/secretsmanager',

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -15,7 +15,7 @@ export class TestStack extends cdk.Stack {
     cdk.Tags.of(scope).add('Hello', 'World');
 
     const keyPair = new KeyPair(this, 'Test-Key-Pair', {
-      name: 'test-key-pair',
+      keyPairName: 'test-key-pair',
       description: 'A test Key Pair',
       removeKeySecretsAfterDays: 0,
       storePublicKey: false,
@@ -33,7 +33,7 @@ export class TestStack extends cdk.Stack {
     // import public key
 
     const keyPairImport = new KeyPair(this, 'Test-Key-Pair-Import', {
-      name: 'test-key-pair-import',
+      keyPairName: 'test-key-pair-import',
       description: 'A test Key Pair, imported via public key',
       removeKeySecretsAfterDays: 0,
       storePublicKey: false,
@@ -49,7 +49,7 @@ export class TestStack extends cdk.Stack {
     // PEM && CloudFront
 
     const keyPairPem = new KeyPair(this, 'Test-Key-Pair-PEM', {
-      name: 'CFN-signing-key',
+      keyPairName: 'CFN-signing-key',
       exposePublicKey: true,
       storePublicKey: true,
       publicKeyFormat: PublicKeyFormat.PEM,


### PR DESCRIPTION
Fixes  #30

### Migration guide

in your KeyPair properteis, change the property `name` to `keyPairName`.

```ts
new KeyPair(this, 'Foo {
  keyPairName: 'CFN-signing-key',
});
```