### PR TITLE
feat!: implements IKeyPair interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,8 @@ This package has peer dependencies, which need to be installed along in the expe
 For TypeScript/NodeJS, add these to your `dependencies` in `package.json`. For Python, add these to your `requirements.txt`:
 
 - cdk-ec2-key-pair
-- aws-cdk-lib (^2.0.0)
+- aws-cdk-lib (^2.116.0)
 - constructs (^10.0.0)
-
-## CDK compatibility
-
-- Version 3.x is compatible with the CDK v2.
-- Version 2.x is compatible with the CDK v1. There won't be updates for this.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [AWS CDK] L3 construct for managing [EC2 Key Pairs].
 
-> ⚠️ Please be aware, CloudFormation now natively supports creating EC2 Key Pairs via [AWS::EC2::KeyPair](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html), so you can generally use [CDK's own KeyPair construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.KeyPair.html). There are a few differences though and this is the reason why this custom construct is still in existence:
+> ⚠️ Please be aware, CloudFormation now natively supports creating EC2 Key Pairs via [AWS::EC2::KeyPair](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html), so you can generally use [CDK's own KeyPair construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.KeyPair.html). There are a few differences though and this is why the custom construct remains valuable:
 >
 > - Instead of SSM Parameter Store, keys are stored in [AWS Secrets Manager]
 > - Secrets can be **KMS encrypted** - even different KMS keys for the private and public keys. Of course, SSM parameters _can_ be encrypted too, CloudFormation just doesn't do it

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 [AWS CDK] L3 construct for managing [EC2 Key Pairs].
 
-> ⚠️ Please be aware, CloudFormation now natively supports creating EC2 Key Pairs via [AWS::EC2::KeyPair](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html), so you can generally use [CDK's own KeyPair construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.KeyPair.html). There are a few differences though and this is why the custom construct remains valuable:
+> [!NOTE]
+> Please be aware, CloudFormation now natively supports creating EC2 Key Pairs via [AWS::EC2::KeyPair](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html), so you can generally use [CDK's own KeyPair construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.KeyPair.html). There are a few differences though and this is why the custom construct remains valuable:
 >
 > - Instead of SSM Parameter Store, keys are stored in [AWS Secrets Manager]
 > - Secrets can be **KMS encrypted** - even different KMS keys for the private and public keys. Of course, SSM parameters _can_ be encrypted too, CloudFormation just doesn't do it
@@ -161,11 +162,11 @@ const trustedKeyGroupForCF = new cloudfront.KeyGroup(
 );
 ```
 
-   [AWS CDK]: https://aws.amazon.com/cdk/
-   [EC2 Key Pairs]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
-   [AWS Secrets Manager]: https://aws.amazon.com/secrets-manager/
-   [npm]: https://www.npmjs.com/package/cdk-ec2-key-pair
-   [PyPI]: https://pypi.org/project/cdk-ec2-key-pair/
-   [docs]: https://constructs.dev/packages/cdk-ec2-key-pair
-   [source]: https://github.com/udondan/cdk-ec2-key-pair
-   [license]: https://github.com/udondan/cdk-ec2-key-pair/blob/main/LICENSE
+[AWS CDK]: https://aws.amazon.com/cdk/
+[EC2 Key Pairs]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
+[AWS Secrets Manager]: https://aws.amazon.com/secrets-manager/
+[npm]: https://www.npmjs.com/package/cdk-ec2-key-pair
+[PyPI]: https://pypi.org/project/cdk-ec2-key-pair/
+[docs]: https://constructs.dev/packages/cdk-ec2-key-pair
+[source]: https://github.com/udondan/cdk-ec2-key-pair
+[license]: https://github.com/udondan/cdk-ec2-key-pair/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [AWS CDK] L3 construct for managing [EC2 Key Pairs].
 
 > [!NOTE]
-> Please be aware, CloudFormation now natively supports creating EC2 Key Pairs via [AWS::EC2::KeyPair](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html), so you can generally use [CDK's own KeyPair construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.KeyPair.html). There are a few differences though and this is why the custom construct remains valuable:
+> Please be aware, CloudFormation now natively supports creating EC2 Key Pairs via [AWS::EC2::KeyPair](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-keypair.html), so you can generally use [CDK's own KeyPair construct](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.KeyPair.html). There are a few differences, though, and this is why the custom construct remains valuable:
 >
 > - Instead of SSM Parameter Store, keys are stored in [AWS Secrets Manager]
 > - Secrets can be **KMS encrypted** - even different KMS keys for the private and public keys. Of course, SSM parameters _can_ be encrypted too, CloudFormation just doesn't do it

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,11 +7,13 @@ import {
   Duration,
   ITaggable,
   Lazy,
+  Resource,
   ResourceProps,
   Stack,
   TagManager,
   TagType,
 } from 'aws-cdk-lib';
+import { IKeyPair, OperatingSystemType } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import { PublicKeyFormat, ResourceProperties } from './types';
@@ -143,7 +145,7 @@ export interface KeyPairProps extends ResourceProps {
 /**
  * An EC2 Key Pair
  */
-export class KeyPair extends Construct implements ITaggable {
+export class KeyPair extends Resource implements ITaggable, IKeyPair {
   /**
    * The lambda function that is created
    */
@@ -409,5 +411,14 @@ export class KeyPair extends Construct implements ITaggable {
       scope: this,
     });
     return result;
+  }
+
+  /**
+   * Used internally to determine whether the key pair is compatible with an OS type.
+   *
+   * @internal
+   */
+  public _isOsCompatible(_osType: OperatingSystemType): boolean {
+    return true; // as we currently only support OpenSSH, we are compatible with all OS types
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "5.4.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "^2.116.0",
     "constructs": "^10.0.0"
   }
 }

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -48,7 +48,7 @@ export class TestStack extends Stack {
       publicKey: keyPair.publicKeyValue,
     });
 
-    if (process.env.with_ec2) {
+    if (process.env.with_ec2 === 'true') {
       new aws_ec2.Instance(this, 'Test-Instance', {
         vpc: aws_ec2.Vpc.fromLookup(this, 'VPC', {
           vpcName: 'default',

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -1,4 +1,11 @@
-import { Tags, StackProps, Stack, CfnOutput, aws_iam } from 'aws-cdk-lib';
+import {
+  Tags,
+  StackProps,
+  Stack,
+  CfnOutput,
+  aws_iam,
+  aws_ec2,
+} from 'aws-cdk-lib';
 import cloudfront = require('aws-cdk-lib/aws-cloudfront');
 import { Construct } from 'constructs';
 import { PublicKeyFormat } from '../../lambda/types';
@@ -40,6 +47,20 @@ export class TestStack extends Stack {
       exposePublicKey: true,
       publicKey: keyPair.publicKeyValue,
     });
+
+    if (process.env.with_ec2) {
+      new aws_ec2.Instance(this, 'Test-Instance', {
+        vpc: aws_ec2.Vpc.fromLookup(this, 'VPC', {
+          vpcName: 'default',
+        }),
+        instanceType: aws_ec2.InstanceType.of(
+          aws_ec2.InstanceClass.T2,
+          aws_ec2.InstanceSize.MICRO,
+        ),
+        machineImage: aws_ec2.MachineImage.latestAmazonLinux2(),
+        keyPair: keyPairImport,
+      });
+    }
 
     new CfnOutput(this, 'Test-Public-Key-Import', {
       exportName: 'TestPublicKeyImport',


### PR DESCRIPTION
For direct use in an ec2 instance construct.

As `IKeyPair` was introduced with aws-cdk-lib [2.116.0](https://github.com/aws/aws-cdk/releases/tag/v2.116.0) this now is the required minimum version. (peerDependency)

Previously you would pass the keyPair name to an EC2  instance, which now is deprecated. You can still pass the name, so no change is required on your end yet. Nevertheless, 2.116.0 is the required min version for this pacakge now. 