### PR TITLE
feat: adds fingerprint and public key format as resource properties

### DIFF
--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -180,6 +180,7 @@ async function createKeyPair(
       log.debug('Import successful', JSON.stringify(result, null, 2));
       resource.addResponseValue('KeyPairName', result.KeyName!);
       resource.addResponseValue('KeyPairID', result.KeyPairId!);
+      resource.addResponseValue('KeyFingerprint', result.KeyFingerprint!);
       return result;
     } catch (error) {
       log.error('Import failed', error);
@@ -203,6 +204,7 @@ async function createKeyPair(
     const result = await ec2Client.send(new CreateKeyPairCommand(params));
     resource.addResponseValue('KeyPairName', result.KeyName!);
     resource.addResponseValue('KeyPairID', result.KeyPairId!);
+    resource.addResponseValue('KeyPairFingerprint', result.KeyFingerprint!);
     return result;
   }
 }
@@ -227,11 +229,9 @@ async function updateKeyPair(
   }
 
   const keyPair = result.KeyPairs[0];
-  const keyPairId = keyPair.KeyPairId!;
-  const keyPairName = keyPair.KeyName!;
-
-  resource.addResponseValue('KeyPairName', keyPairName);
-  resource.addResponseValue('KeyPairID', keyPairId);
+  resource.addResponseValue('KeyPairName', keyPair.KeyName!);
+  resource.addResponseValue('KeyPairID', keyPair.KeyPairId!);
+  resource.addResponseValue('KeyPairFingerprint', keyPair.KeyFingerprint!);
   return keyPair;
 }
 
@@ -330,7 +330,6 @@ async function deleteKeyPair(
   };
   log.debug('ec2.deleteKeyPair:', JSON.stringify(params, null, 2));
   await ec2Client.send(new DeleteKeyPairCommand(params));
-  resource.addResponseValue('KeyPairName', resource.properties.Name.value);
 }
 
 async function createPrivateKeySecret(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -198,6 +198,16 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
   public readonly keyPairID: string = '';
 
   /**
+   * Fingerprint of the Key Pair
+   */
+  public readonly keyPairFingerprint: string = '';
+
+  /**
+   * Format of the public key
+   */
+  public readonly publicKeyFormat: PublicKeyFormat;
+
+  /**
    * Type of the Key Pair
    */
   public readonly keyType: KeyType;
@@ -264,6 +274,7 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
     this.tags.setTag(createdByTag, ID);
 
     this.keyType = props.keyType ?? KeyType.RSA;
+    this.publicKeyFormat = props.publicKeyFormat ?? PublicKeyFormat.SSH;
 
     const kmsPrivate = props.kmsPrivateKey ?? props.kms;
     const kmsPublic = props.kmsPublicKey ?? props.kms;
@@ -318,6 +329,7 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
     this.publicKeyValue = key.getAttString('PublicKeyValue');
     this.keyPairName = key.getAttString('KeyPairName');
     this.keyPairID = key.getAttString('KeyPairID');
+    this.keyPairFingerprint = key.getAttString('KeyPairFingerprint');
   }
 
   private ensureLambda(legacyLambdaName: boolean): aws_lambda.Function {

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -46,7 +46,7 @@ export class TestStack extends Stack {
     });
 
     new CfnOutput(this, 'Test-Public-Key-Format', {
-      exportName: 'TestPublicKeyFingerprint',
+      exportName: 'TestPublicKeyFormat',
       value: keyPair.publicKeyFormat,
     });
 

--- a/test/lib/test-stack.ts
+++ b/test/lib/test-stack.ts
@@ -40,6 +40,16 @@ export class TestStack extends Stack {
       value: keyPair.publicKeyValue,
     });
 
+    new CfnOutput(this, 'Test-Public-Key-Fingerprint', {
+      exportName: 'TestPublicKeyFingerprint',
+      value: keyPair.keyPairFingerprint,
+    });
+
+    new CfnOutput(this, 'Test-Public-Key-Format', {
+      exportName: 'TestPublicKeyFingerprint',
+      value: keyPair.publicKeyFormat,
+    });
+
     // import public key
 
     const keyPairImport = new KeyPair(this, 'Test-Key-Pair-Import', {


### PR DESCRIPTION
On a keypair, now you can access `.publicKeyFormat` and `.keyPairFingerprint`.