### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ![Downloads](https://img.shields.io/badge/-DOWNLOADS:-brightgreen?color=gray)
 [![npm](https://img.shields.io/npm/dt/cdk-ec2-key-pair?label=npm&color=blueviolet)][npm]
 [![PyPI](https://img.shields.io/pypi/dm/cdk-ec2-key-pair?label=pypi&color=blueviolet)][PyPI]
+[![github network dependents](https://dependents.info/udondan/cdk-ec2-key-pair/badge?color=blueviolet)](https://dependents.info/udondan/cdk-ec2-key-pair)
 
 [AWS CDK] L3 construct for managing [EC2 Key Pairs].
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="688" alt="image" src="https://github.com/user-attachments/assets/14c8d581-826e-4a8e-a5c0-1a8c10130627" />
<br /><br />

I haven't included the full image yet, but I can update the PR if you think it'll be good. [Here's](https://github.com/joshnuss/svelte-persisted-store) a project using it already.

Please feel free to close the PR if you don't want to have this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new workflow to monitor repository dependents on a scheduled and manual basis.

* **Documentation**
  * Introduced a badge in the README to display the repository's dependents count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->