### PR TITLE
chore: remove unused devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@swc/core": "1.15.26",
         "@swc/helpers": "0.5.21",
         "@types/node": "24.9.1",
-        "@types/node-forge": "1.3.14",
         "@types/sshpk": "1.17.4",
         "@typescript-eslint/eslint-plugin": "8.58.2",
         "@typescript-eslint/parser": "8.58.2",
@@ -27,10 +26,8 @@
         "eslint-plugin-prettier": "5.5.5",
         "jsii": "5.9.37",
         "jsii-pacmak": "1.128.0",
-        "node-forge": "1.4.0",
         "prettier": "3.8.3",
         "publib": "0.2.1041",
-        "regenerator-runtime": "0.14.1",
         "ts-node": "10.9.2",
         "typescript": "5.9.3",
         "typescript-eslint": "8.58.2"
@@ -2328,16 +2325,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/sshpk": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/@types/sshpk/-/sshpk-1.17.4.tgz",
@@ -4380,16 +4367,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/oo-ascii-tree": {
       "version": "1.128.0",
       "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.128.0.tgz",
@@ -4710,12 +4687,6 @@
         }
       ],
       "peer": true
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@swc/core": "1.15.26",
     "@swc/helpers": "0.5.21",
     "@types/node": "24.9.1",
-    "@types/node-forge": "1.3.14",
     "@types/sshpk": "1.17.4",
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
@@ -74,10 +73,8 @@
     "eslint-plugin-prettier": "5.5.5",
     "jsii": "5.9.37",
     "jsii-pacmak": "1.128.0",
-    "node-forge": "1.4.0",
     "prettier": "3.8.3",
     "publib": "0.2.1041",
-    "regenerator-runtime": "0.14.1",
     "ts-node": "10.9.2",
     "typescript": "5.9.3",
     "typescript-eslint": "8.58.2"


### PR DESCRIPTION
Removes three `devDependencies` that are never imported in any source file (`lib/`, `lambda/`, or `test/`) and not referenced in any build or config file:

- `node-forge` — unused; was bumped to 1.4.0 on main but still not referenced anywhere
- `@types/node-forge` — types for the above unused package
- `regenerator-runtime` — unused; not referenced in any tsconfig or build script