### PR TITLE
chore: add lambda tsconfig to fix CommonJS output with TypeScript 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lambda/*
 !lambda/build
 !lambda/package.json
 !lambda/package-lock.json
+!lambda/tsconfig.json
 **/*.js
 !eslint.config.js
 **/*.d.ts

--- a/lambda/build
+++ b/lambda/build
@@ -3,6 +3,6 @@
 set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 npm clean-install --prefer-offline --cache ../.npm
-npx tsc ./*.ts
+npx tsc
 zip -r code.zip ./*.js node_modules
 rm ./*.js

--- a/lambda/tsconfig.json
+++ b/lambda/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
## Summary

- TypeScript 6 changed the default `module` compiler option from `commonjs` to `esnext`, causing the Lambda to emit ES module syntax (`import`/`export`) instead of CommonJS (`require`/`exports`)
- The Lambda build script passed file paths directly to `tsc` (`npx tsc ./*.ts`), which causes TypeScript to ignore `tsconfig.json` — so the root config's `"module": "commonjs"` was never applied
- This worked silently with TypeScript 5 because the implicit default was `commonjs`; TypeScript 6 broke it

## Changes

- **`lambda/tsconfig.json`** (new): Explicit compiler config for the Lambda with `"module": "commonjs"` and matching `target`/`lib`/strict settings
- **`lambda/build`**: Drop explicit file args (`npx tsc ./*.ts` → `npx tsc`) so TypeScript picks up the tsconfig
- **`.gitignore`**: Allowlist `lambda/tsconfig.json` (the `lambda/*` glob was blocking it)

## Test plan

- [ ] Lambda build produces `require()`/`exports` CommonJS output (verified locally: first 5 lines of `index.js` show `"use strict"` + `exports` + `require()`)
- [ ] Test pipeline passes in CI