### PR TITLE
feat: add lambdaRuntime prop and bump default to NODEJS_24_X

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ Since an EC2 KeyPair cannot be updated, you cannot change any property related t
 
 You can, however, change properties that only relate to the secrets. These are the KMS keys used for encryption, the `secretPrefix`, `description` and `removeKeySecretsAfterDays`.
 
+### Customizing the Lambda runtime
+
+The backing Lambda function defaults to the `NODEJS_24_X` runtime. If you need to pin to a specific Node.js version, pass the `lambdaRuntime` property:
+
+```typescript
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+
+const keyPair = new KeyPair(this, 'A-Key-Pair', {
+  keyPairName: 'a-key-pair',
+  lambdaRuntime: Runtime.NODEJS_22_X,
+});
+```
+
+> **Note:** The Lambda function is shared across all `KeyPair` instances in the same stack. Only the value set on the first instance takes effect.
+
 ### Encryption
 
 Secrets in the AWS Secrets Manager by default are encrypted with the key `alias/aws/secretsmanager`.

--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -38,7 +38,6 @@ import {
 } from '@aws-sdk/client-secrets-manager';
 import {
   Context,
-  Callback,
   CustomResource,
   Event,
   LogLevel,
@@ -50,28 +49,35 @@ import { PublicKeyFormat, ResourceProperties } from './types';
 
 const ec2Client = new EC2Client({});
 const secretsManagerClient = new SecretsManagerClient({});
-export const handler = function (
+export const handler = async function (
   event: Event<ResourceProperties>,
   context: Context,
-  callback: Callback,
-) {
-  const resource = new CustomResource<ResourceProperties>(
-    event,
-    context,
-    callback,
-    createResource,
-    updateResource,
-    deleteResource,
-  );
-
-  if (event.ResourceProperties.LogLevel) {
-    resource.setLogger(
-      new StandardLogger(
-        // because jsii is forcing us to expose enums with all capitals and the enum in aws-cloudformation-custom-resource is all lowercase, we need to cast here. Other than the capitalization, the enums are identical
-        event.ResourceProperties.LogLevel as unknown as LogLevel,
-      ),
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const resource = new CustomResource<ResourceProperties>(
+      event,
+      context,
+      (error) => {
+        if (error) {
+          reject(typeof error === 'string' ? new Error(error) : error);
+        } else {
+          resolve();
+        }
+      },
+      createResource,
+      updateResource,
+      deleteResource,
     );
-  }
+
+    if (event.ResourceProperties.LogLevel) {
+      resource.setLogger(
+        new StandardLogger(
+          // because jsii is forcing us to expose enums with all capitals and the enum in aws-cloudformation-custom-resource is all lowercase, we need to cast here. Other than the capitalization, the enums are identical
+          event.ResourceProperties.LogLevel as unknown as LogLevel,
+        ),
+      );
+    }
+  });
 };
 
 async function createResource(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -366,7 +366,10 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
     this.keyPairFingerprint = key.getAttString('KeyPairFingerprint');
   }
 
-  private ensureLambda(legacyLambdaName: boolean, runtime: aws_lambda.Runtime): aws_lambda.Function {
+  private ensureLambda(
+    legacyLambdaName: boolean,
+    runtime: aws_lambda.Runtime,
+  ): aws_lambda.Function {
     const stack = Stack.of(this);
     const constructName = legacyLambdaName
       ? 'EC2-Key-Name-Manager-Lambda' // this name was not intentional but we keep it for legacy resources

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -161,6 +161,16 @@ export interface KeyPairProps extends ResourceProps {
    * @default LogLevel.warn
    */
   readonly logLevel?: LogLevel;
+
+  /**
+   * The Node.js runtime to use for the Lambda function backing the custom resource.
+   *
+   * Since this Lambda function is shared across all `KeyPair` instances in the same stack,
+   * only the value set on the first instance takes effect.
+   *
+   * @default aws_lambda.Runtime.NODEJS_24_X
+   */
+  readonly lambdaRuntime?: aws_lambda.Runtime;
 }
 
 /**
@@ -277,7 +287,10 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
         );
       }
     }
-    this.lambdaFunction = this.ensureLambda(props.legacyLambdaName ?? false);
+    this.lambdaFunction = this.ensureLambda(
+      props.legacyLambdaName ?? false,
+      props.lambdaRuntime ?? aws_lambda.Runtime.NODEJS_24_X,
+    );
 
     this.tags = new TagManager(TagType.MAP, 'Custom::EC2-Key-Pair');
     this.tags.setTag(createdByTag, ID);
@@ -353,7 +366,7 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
     this.keyPairFingerprint = key.getAttString('KeyPairFingerprint');
   }
 
-  private ensureLambda(legacyLambdaName: boolean): aws_lambda.Function {
+  private ensureLambda(legacyLambdaName: boolean, runtime: aws_lambda.Runtime): aws_lambda.Function {
     const stack = Stack.of(this);
     const constructName = legacyLambdaName
       ? 'EC2-Key-Name-Manager-Lambda' // this name was not intentional but we keep it for legacy resources
@@ -440,7 +453,7 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
     const fn = new aws_lambda.Function(stack, constructName, {
       functionName: legacyLambdaName ? `${this.prefix}-${cleanID}` : undefined,
       description: 'Custom CFN resource: Manage EC2 Key Pairs',
-      runtime: aws_lambda.Runtime.NODEJS_22_X,
+      runtime: runtime,
       handler: 'index.handler',
       code: aws_lambda.Code.fromAsset(
         path.join(__dirname, '../lambda/code.zip'),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -267,6 +267,15 @@ export class KeyPair extends Resource implements ITaggable, IKeyPair {
     }
 
     if (
+      props.lambdaRuntime !== undefined &&
+      props.lambdaRuntime.family !== aws_lambda.RuntimeFamily.NODEJS
+    ) {
+      Annotations.of(this).addError(
+        `Parameter lambdaRuntime must be a Node.js runtime. Got ${props.lambdaRuntime.name}`,
+      );
+    }
+
+    if (
       props.keyType == KeyType.ED25519 &&
       props.publicKeyFormat == PublicKeyFormat.PKCS1
     ) {


### PR DESCRIPTION
## Summary

- Adds an optional `lambdaRuntime` property to `KeyPairProps` so users can specify which Node.js runtime the backing Lambda function uses, without waiting for a new library release
- Bumps the default runtime from `NODEJS_22_X` to `NODEJS_24_X` (current Node.js LTS)
- Documents the new option in the README with a code example

## Details

The Lambda function that backs the custom CloudFormation resource is shared across all `KeyPair` instances in the same stack (singleton pattern). Only the first instance's `lambdaRuntime` value takes effect, consistent with the existing `legacyLambdaName` behavior. This is documented in the JSDoc.

Closes #1296