### PR TITLE
chore: upgrade Node.js in publish workflow to fix OIDC trusted publisher auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
       image: public.ecr.aws/jsii/superchain:1-bookworm-slim-node20
 
     steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Root cause

PR #1464 switched npm publishing to OIDC trusted publisher (`NPM_TRUSTED_PUBLISHER=true`). This requires the npm CLI to perform an OIDC token exchange with the registry. The npm version in the `superchain:1-bookworm-slim-node20` container is too old to support this exchange, so `npm publish` fails immediately with `ENEEDAUTH`.

## Fix

Add `actions/setup-node@v6` with `node-version: 24.x` before checkout — identical to what `.github/workflows/test.yml` already does inside the same container. Node.js 24 ships with npm 11 which supports the OIDC trusted publisher auth flow.

## Verification

Trigger the publish workflow manually after merging, or wait for the next tag push.